### PR TITLE
TDD 로 사용자의 포인트 조회/충전/사용 API 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,8 +22,12 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
     implementation(libs.spring.boot.starter.web)
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.19.1")
     annotationProcessor(libs.spring.boot.configuration.processor)
     testImplementation(libs.spring.boot.starter.test)
+    testImplementation("io.kotest:kotest-runner-junit5:5.8.0")
+    testImplementation("io.mockk:mockk:1.14.4")
+
 }
 
 // about source and compilation

--- a/src/main/kotlin/io/hhplus/tdd/ApiControllerAdvice.kt
+++ b/src/main/kotlin/io/hhplus/tdd/ApiControllerAdvice.kt
@@ -21,4 +21,13 @@ class ApiControllerAdvice : ResponseEntityExceptionHandler() {
             HttpStatus.INTERNAL_SERVER_ERROR,
         )
     }
+
+    @ExceptionHandler(IllegalArgumentException::class)
+    fun handleIllegalArgumentException(e: IllegalArgumentException): ResponseEntity<ErrorResponse> {
+        logger.error("IllegalArgumentException: ${e.message}", e)
+        return ResponseEntity(
+            ErrorResponse("400", e.message ?: "잘못된 요청입니다."),
+            HttpStatus.BAD_REQUEST,
+        )
+    }
 }

--- a/src/main/kotlin/io/hhplus/tdd/point/PointController.kt
+++ b/src/main/kotlin/io/hhplus/tdd/point/PointController.kt
@@ -22,15 +22,12 @@ class PointController(
         return pointService.getPointHistoriesByUserId(id)
     }
 
-    /**
-     * TODO - 특정 유저의 포인트를 충전하는 기능을 작성해주세요.
-     */
     @PatchMapping("{id}/charge")
     fun charge(
         @PathVariable id: Long,
         @RequestBody amount: Long,
     ): UserPoint {
-        return UserPoint(0, 0, 0)
+        return pointService.chargePoint(id, amount)
     }
 
     /**

--- a/src/main/kotlin/io/hhplus/tdd/point/PointController.kt
+++ b/src/main/kotlin/io/hhplus/tdd/point/PointController.kt
@@ -1,7 +1,5 @@
 package io.hhplus.tdd.point
 
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
 import org.springframework.web.bind.annotation.*
 
 @RestController
@@ -17,14 +15,11 @@ class PointController(
         return pointService.getPointByUserId(id)
     }
 
-    /**
-     * TODO - 특정 유저의 포인트 충전/이용 내역을 조회하는 기능을 작성해주세요.
-     */
     @GetMapping("{id}/histories")
     fun history(
         @PathVariable id: Long,
     ): List<PointHistory> {
-        return emptyList()
+        return pointService.getPointHistoriesByUserId(id)
     }
 
     /**

--- a/src/main/kotlin/io/hhplus/tdd/point/PointController.kt
+++ b/src/main/kotlin/io/hhplus/tdd/point/PointController.kt
@@ -30,14 +30,11 @@ class PointController(
         return pointService.chargePoint(id, amount)
     }
 
-    /**
-     * TODO - 특정 유저의 포인트를 사용하는 기능을 작성해주세요.
-     */
     @PatchMapping("{id}/use")
     fun use(
         @PathVariable id: Long,
         @RequestBody amount: Long,
     ): UserPoint {
-        return UserPoint(0, 0, 0)
+        return pointService.usePoint(id, amount)
     }
 }

--- a/src/main/kotlin/io/hhplus/tdd/point/PointController.kt
+++ b/src/main/kotlin/io/hhplus/tdd/point/PointController.kt
@@ -6,17 +6,15 @@ import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("/point")
-class PointController {
-    private val logger: Logger = LoggerFactory.getLogger(javaClass)
+class PointController(
+    private val pointService: PointService
+) {
 
-    /**
-     * TODO - 특정 유저의 포인트를 조회하는 기능을 작성해주세요.
-     */
     @GetMapping("{id}")
     fun point(
         @PathVariable id: Long,
     ): UserPoint {
-        return UserPoint(0, 0, 0)
+        return pointService.getPointByUserId(id)
     }
 
     /**

--- a/src/main/kotlin/io/hhplus/tdd/point/PointHistory.kt
+++ b/src/main/kotlin/io/hhplus/tdd/point/PointHistory.kt
@@ -6,7 +6,12 @@ data class PointHistory(
     val type: TransactionType,
     val amount: Long,
     val timeMillis: Long,
-)
+) {
+    companion object {
+        fun chargeHistory(userId: Long, amount: Long, timeMillis: Long = System.currentTimeMillis()): PointHistory =
+            PointHistory(0L, userId, TransactionType.CHARGE, amount, timeMillis)
+    }
+}
 
 /**
  * 포인트 트랜잭션 종류

--- a/src/main/kotlin/io/hhplus/tdd/point/PointHistory.kt
+++ b/src/main/kotlin/io/hhplus/tdd/point/PointHistory.kt
@@ -10,6 +10,9 @@ data class PointHistory(
     companion object {
         fun chargeHistory(userId: Long, amount: Long, timeMillis: Long = System.currentTimeMillis()): PointHistory =
             PointHistory(0L, userId, TransactionType.CHARGE, amount, timeMillis)
+
+        fun useHistory(userId: Long, amount: Long, timeMillis: Long = System.currentTimeMillis()): PointHistory =
+            PointHistory(0L, userId, TransactionType.USE, amount, timeMillis)
     }
 }
 

--- a/src/main/kotlin/io/hhplus/tdd/point/PointService.kt
+++ b/src/main/kotlin/io/hhplus/tdd/point/PointService.kt
@@ -27,4 +27,13 @@ class PointService(
         return userPointRepository.save(pointAddedUserPoint)
     }
 
+    fun usePoint(id: Long, amount: Long): UserPoint {
+        val userPoint = userPointRepository.getPointByUserId(id)
+        val pointUsedUserPoint = userPoint.usePoint(amount)
+
+        pointHistoryRepository.save(PointHistory.useHistory(id, amount))
+
+        return userPointRepository.save(pointUsedUserPoint)
+    }
+
 }

--- a/src/main/kotlin/io/hhplus/tdd/point/PointService.kt
+++ b/src/main/kotlin/io/hhplus/tdd/point/PointService.kt
@@ -18,4 +18,13 @@ class PointService(
         return pointHistoryRepository.findByUserId(id)
     }
 
+    fun chargePoint(id: Long, amount: Long): UserPoint {
+        val userPoint = userPointRepository.getPointByUserId(id)
+        val pointAddedUserPoint = userPoint.addPoint(amount)
+
+        pointHistoryRepository.save(PointHistory.chargeHistory(id, amount))
+
+        return userPointRepository.save(pointAddedUserPoint)
+    }
+
 }

--- a/src/main/kotlin/io/hhplus/tdd/point/PointService.kt
+++ b/src/main/kotlin/io/hhplus/tdd/point/PointService.kt
@@ -1,15 +1,21 @@
 package io.hhplus.tdd.point
 
+import io.hhplus.tdd.point.repository.PointHistoryRepository
 import io.hhplus.tdd.point.repository.UserPointRepository
 import org.springframework.stereotype.Service
 
 @Service
 class PointService(
     private val userPointRepository: UserPointRepository,
+    private val pointHistoryRepository: PointHistoryRepository
 ) {
 
     fun getPointByUserId(userId: Long): UserPoint {
         return userPointRepository.getPointByUserId(userId)
+    }
+
+    fun getPointHistoriesByUserId(id: Long): List<PointHistory> {
+        return pointHistoryRepository.findByUserId(id)
     }
 
 }

--- a/src/main/kotlin/io/hhplus/tdd/point/PointService.kt
+++ b/src/main/kotlin/io/hhplus/tdd/point/PointService.kt
@@ -1,0 +1,15 @@
+package io.hhplus.tdd.point
+
+import io.hhplus.tdd.point.repository.UserPointRepository
+import org.springframework.stereotype.Service
+
+@Service
+class PointService(
+    private val userPointRepository: UserPointRepository,
+) {
+
+    fun getPointByUserId(userId: Long): UserPoint {
+        return userPointRepository.getPointByUserId(userId)
+    }
+
+}

--- a/src/main/kotlin/io/hhplus/tdd/point/UserPoint.kt
+++ b/src/main/kotlin/io/hhplus/tdd/point/UserPoint.kt
@@ -5,3 +5,10 @@ data class UserPoint(
     val point: Long,
     val updateMillis: Long,
 )
+) {
+
+    fun addPoint(amount: Long): UserPoint {
+        require(amount >= 0) { "추가할 포인트는 0 이상이어야 합니다." }
+        return this.copy(point = this.point + amount, updateMillis = System.currentTimeMillis())
+    }
+}

--- a/src/main/kotlin/io/hhplus/tdd/point/UserPoint.kt
+++ b/src/main/kotlin/io/hhplus/tdd/point/UserPoint.kt
@@ -4,11 +4,17 @@ data class UserPoint(
     val id: Long,
     val point: Long,
     val updateMillis: Long,
-)
 ) {
 
     fun addPoint(amount: Long): UserPoint {
         require(amount >= 0) { "추가할 포인트는 0 이상이어야 합니다." }
         return this.copy(point = this.point + amount, updateMillis = System.currentTimeMillis())
     }
+
+    fun usePoint(amount: Long): UserPoint {
+        require(amount >= 0) { "사용할 포인트는 0 이상이어야 합니다." }
+        require(this.point >= amount) { "포인트가 부족합니다." }
+        return this.copy(point = this.point - amount, updateMillis = System.currentTimeMillis())
+    }
+
 }

--- a/src/main/kotlin/io/hhplus/tdd/point/repository/PointHistoryRepository.kt
+++ b/src/main/kotlin/io/hhplus/tdd/point/repository/PointHistoryRepository.kt
@@ -11,4 +11,7 @@ class PointHistoryRepository(
 
     fun findByUserId(userId: Long): List<PointHistory> = pointHistoryTable.selectAllByUserId(userId)
 
+    fun save(pointHistory: PointHistory): PointHistory =
+        pointHistoryTable.insert(pointHistory.userId, pointHistory.amount, pointHistory.type, pointHistory.timeMillis)
+
 }

--- a/src/main/kotlin/io/hhplus/tdd/point/repository/PointHistoryRepository.kt
+++ b/src/main/kotlin/io/hhplus/tdd/point/repository/PointHistoryRepository.kt
@@ -1,0 +1,14 @@
+package io.hhplus.tdd.point.repository
+
+import io.hhplus.tdd.database.PointHistoryTable
+import io.hhplus.tdd.point.PointHistory
+import org.springframework.stereotype.Repository
+
+@Repository
+class PointHistoryRepository(
+    private val pointHistoryTable: PointHistoryTable
+) {
+
+    fun findByUserId(userId: Long): List<PointHistory> = pointHistoryTable.selectAllByUserId(userId)
+
+}

--- a/src/main/kotlin/io/hhplus/tdd/point/repository/UserPointRepository.kt
+++ b/src/main/kotlin/io/hhplus/tdd/point/repository/UserPointRepository.kt
@@ -1,0 +1,14 @@
+package io.hhplus.tdd.point.repository
+
+import io.hhplus.tdd.database.UserPointTable
+import io.hhplus.tdd.point.UserPoint
+import org.springframework.stereotype.Repository
+
+@Repository
+class UserPointRepository(
+    private val userPointTable: UserPointTable
+) {
+
+    fun getPointByUserId(userId: Long): UserPoint = userPointTable.selectById(userId)
+
+}

--- a/src/main/kotlin/io/hhplus/tdd/point/repository/UserPointRepository.kt
+++ b/src/main/kotlin/io/hhplus/tdd/point/repository/UserPointRepository.kt
@@ -11,4 +11,6 @@ class UserPointRepository(
 
     fun getPointByUserId(userId: Long): UserPoint = userPointTable.selectById(userId)
 
+    fun save(userPoint: UserPoint): UserPoint = userPointTable.insertOrUpdate(userPoint.id, userPoint.point)
+
 }

--- a/src/test/kotlin/io/hhplus/tdd/point/PointControllerIntegrationTest.kt
+++ b/src/test/kotlin/io/hhplus/tdd/point/PointControllerIntegrationTest.kt
@@ -1,0 +1,197 @@
+package io.hhplus.tdd.point
+
+import io.hhplus.tdd.database.PointHistoryTable
+import io.hhplus.tdd.database.UserPointTable
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.get
+import org.springframework.test.web.servlet.patch
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class PointControllerIntegrationTest @Autowired constructor(
+    val mockMvc: MockMvc,
+    val pointHistoryTable: PointHistoryTable,
+    val userPointTable: UserPointTable
+) {
+
+    @Test
+    fun `포인트가 없는 유저의 포인트 조회 플로우`() {
+        val userId = 1L
+
+        mockMvc.get("/point/$userId")
+            .andExpect {
+                status().isOk
+                content {
+                    contentType(MediaType.APPLICATION_JSON)
+                    jsonPath("$.id") { value("1") }
+                    jsonPath("$.point") { value("0") }
+                    jsonPath("$.updateMillis") { isNumber() }
+                }
+            }
+    }
+
+    @Test
+    fun `포인트가 없는 유저의 포인트 히스토리 조회 플로우`() {
+        val userId = 2L
+
+        mockMvc.get("/point/$userId/histories")
+            .andExpect {
+                status().isOk
+                content {
+                    contentType(MediaType.APPLICATION_JSON)
+                    jsonPath("$") { isArray() }
+                    jsonPath("$") { isEmpty() }
+                }
+            }
+    }
+
+    @Test
+    fun `포인트가(충전한 이력이) 있는 유저의 포인트 조회 플로우`() {
+        val userId = 3L
+        val amount = 1000L
+
+        pointHistoryTable.insert(userId, amount, TransactionType.CHARGE, System.currentTimeMillis())
+        userPointTable.insertOrUpdate(userId, amount)
+
+        mockMvc.get("/point/$userId")
+            .andExpect {
+                status().isOk
+                content {
+                    contentType(MediaType.APPLICATION_JSON)
+                    jsonPath("$.id") { value("$userId") }
+                    jsonPath("$.point") { value("$amount") }
+                    jsonPath("$.updateMillis") { isNumber() }
+                }
+            }
+    }
+
+    @Test
+    fun `포인트가(충전한 이력이) 있는 유저의 포인트 히스토리 조회 플로우`() {
+        val userId = 4L
+        val chargeAmount = 1000L
+        val useAmount = 500L
+
+        pointHistoryTable.insert(userId, chargeAmount, TransactionType.CHARGE, System.currentTimeMillis())
+        pointHistoryTable.insert(userId, useAmount, TransactionType.USE, System.currentTimeMillis())
+        userPointTable.insertOrUpdate(userId, chargeAmount - useAmount)
+
+        mockMvc.get("/point/$userId/histories")
+            .andExpect {
+                status().isOk
+                content {
+                    contentType(MediaType.APPLICATION_JSON)
+                    jsonPath("$[0].userId") { value("$userId") }
+                    jsonPath("$[0].amount") { value("$chargeAmount") }
+                    jsonPath("$[0].type") { value("CHARGE") }
+                    jsonPath("$[1].userId") { value("$userId") }
+                    jsonPath("$[1].amount") { value("$useAmount") }
+                    jsonPath("$[1].type") { value("USE") }
+                }
+            }
+    }
+
+    @Test
+    fun `포인트 충전 플로우`() {
+        val userId = 5L
+        val chargeAmount = 500L
+
+        mockMvc.patch("/point/$userId/charge") {
+            contentType = MediaType.APPLICATION_JSON
+            content = "$chargeAmount"
+        }.andExpect {
+            status().isOk
+            content {
+                contentType(MediaType.APPLICATION_JSON)
+                jsonPath("$.id") { value("$userId") }
+                jsonPath("$.point") { value("$chargeAmount") }
+                jsonPath("$.updateMillis") { isNumber() }
+            }
+        }
+    }
+
+    @Test
+    fun `포인트 충전 후 사용 플로우`() {
+        val userId = 6L
+        val chargeAmount = 500L
+        val useAmount = 200L
+
+        // 포인트 충전
+        mockMvc.patch("/point/$userId/charge") {
+            contentType = MediaType.APPLICATION_JSON
+            content = "$chargeAmount"
+        }.andExpect {
+            status().isOk
+            content {
+                contentType(MediaType.APPLICATION_JSON)
+                jsonPath("$.id") { value("$userId") }
+                jsonPath("$.point") { value("$chargeAmount") }
+                jsonPath("$.updateMillis") { isNumber() }
+            }
+        }
+
+        // 포인트 사용
+        mockMvc.patch("/point/$userId/use") {
+            contentType = MediaType.APPLICATION_JSON
+            content = "$useAmount"
+        }.andExpect {
+            status().isOk
+            content {
+                contentType(MediaType.APPLICATION_JSON)
+                jsonPath("$.id") { value("$userId") }
+                jsonPath("$.point") { value("${chargeAmount - useAmount}") }
+                jsonPath("$.updateMillis") { isNumber() }
+            }
+        }
+
+        // 포인트 사용 후 히스토리 조회
+        mockMvc.get("/point/$userId/histories")
+            .andExpect {
+                status().isOk
+                content {
+                    contentType(MediaType.APPLICATION_JSON)
+                    jsonPath("$[0].userId") { value("$userId") }
+                    jsonPath("$[0].amount") { value("$chargeAmount") }
+                    jsonPath("$[0].type") { value("CHARGE") }
+                    jsonPath("$[1].userId") { value("$userId") }
+                    jsonPath("$[1].amount") { value("$useAmount") }
+                    jsonPath("$[1].type") { value("USE") }
+                }
+            }
+    }
+
+    @Test
+    fun `포인트 부족으로 인한 포인트 사용 실패 플로우`() {
+        val userId = 7L
+        val chargeAmount = 500L
+        val useAmount = 600L
+
+        // 포인트 충전
+        mockMvc.patch("/point/$userId/charge") {
+            contentType = MediaType.APPLICATION_JSON
+            content = "$chargeAmount"
+        }.andExpect {
+            status().isOk
+            content {
+                contentType(MediaType.APPLICATION_JSON)
+                jsonPath("$.id") { value("$userId") }
+                jsonPath("$.point") { value("$chargeAmount") }
+                jsonPath("$.updateMillis") { isNumber() }
+            }
+        }
+
+        // 보유한 포인트보다 많은 포인트 사용 시도
+        mockMvc.patch("/point/$userId/use") {
+            contentType = MediaType.APPLICATION_JSON
+            content = "$useAmount"
+        }.andExpect {
+            status().isBadRequest
+        }
+    }
+
+}

--- a/src/test/kotlin/io/hhplus/tdd/point/PointControllerTest.kt
+++ b/src/test/kotlin/io/hhplus/tdd/point/PointControllerTest.kt
@@ -102,4 +102,27 @@ class PointControllerTest {
         verify(exactly = 1) { pointService.chargePoint(userId, chargeAmount) }
     }
 
+    @Test
+    fun useUserPointApi() {
+        val userId = 1L
+        val useAmount = 300L
+        val updatedUserPoint = UserPoint(userId, 700L, System.currentTimeMillis())
+
+        every { pointService.usePoint(userId, useAmount) } returns updatedUserPoint
+
+        mockMvc.patch("/point/$userId/use") {
+            contentType = MediaType.APPLICATION_JSON
+            content = objectMapper.writeValueAsString(useAmount)
+        }.andExpect {
+            status { isOk() }
+            content {
+                contentType(MediaType.APPLICATION_JSON)
+                jsonPath("$.id", userId.toString())
+                jsonPath("$.point", "700")
+            }
+        }
+
+        verify(exactly = 1) { pointService.usePoint(userId, useAmount) }
+    }
+
 }

--- a/src/test/kotlin/io/hhplus/tdd/point/PointControllerTest.kt
+++ b/src/test/kotlin/io/hhplus/tdd/point/PointControllerTest.kt
@@ -40,6 +40,46 @@ class PointControllerTest {
     }
 
     @Test
+    fun getUserPointHistoriesApi() {
+        val userId = 1L
+        val histories = listOf(
+            PointHistory(
+                id = 1L,
+                userId = userId,
+                amount = 100L,
+                type = TransactionType.CHARGE,
+                timeMillis = System.currentTimeMillis()
+            ),
+            PointHistory(
+                id = 2L,
+                userId = userId,
+                amount = 50L,
+                type = TransactionType.USE,
+                timeMillis = System.currentTimeMillis()
+            )
+        )
+        every { pointService.getPointHistoriesByUserId(userId) } returns histories
+
+        mockMvc.get("/point/$userId/histories")
+            .andExpect {
+                status { isOk() }
+                content {
+                    contentType(MediaType.APPLICATION_JSON)
+                    jsonPath("$[0].id", "1")
+                    jsonPath("$[0].userId", userId)
+                    jsonPath("$[0].amount", "100")
+                    jsonPath("$[0].type", "CHARGE")
+                    jsonPath("$[1].id", "2")
+                    jsonPath("$[1].userId", userId)
+                    jsonPath("$[1].amount", "50")
+                    jsonPath("$[1].type", "USE")
+                }
+            }
+
+        verify(exactly = 1) { pointService.getPointHistoriesByUserId(userId) }
+    }
+
+    @Test
     fun chargeUserPointApi() {
         val userId = 1L
         val chargeAmount = 500L

--- a/src/test/kotlin/io/hhplus/tdd/point/PointControllerTest.kt
+++ b/src/test/kotlin/io/hhplus/tdd/point/PointControllerTest.kt
@@ -1,0 +1,38 @@
+package io.hhplus.tdd.point
+
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+
+class PointControllerTest {
+
+    private val pointService = mockk<PointService>()
+    private val pointController = PointController(pointService)
+
+    private val mockMvc: MockMvc = MockMvcBuilders.standaloneSetup(pointController).build()
+
+    @Test
+    fun getUserPointApi() {
+        val userId = 1L
+        val expectedUserPoint = UserPoint(userId, 1000L, System.currentTimeMillis())
+
+        every { pointService.getPointByUserId(userId) } returns expectedUserPoint
+
+        mockMvc.get("/point/$userId") {
+            accept = MediaType.APPLICATION_JSON
+        }.andExpect {
+            status { isOk() }
+            content {
+                contentType(MediaType.APPLICATION_JSON)
+                jsonPath("$.id", userId.toString())
+                jsonPath("$.point", "1000")
+            }
+        }
+    }
+
+}

--- a/src/test/kotlin/io/hhplus/tdd/point/PointServiceTest.kt
+++ b/src/test/kotlin/io/hhplus/tdd/point/PointServiceTest.kt
@@ -1,0 +1,25 @@
+package io.hhplus.tdd.point
+
+import io.hhplus.tdd.point.repository.UserPointRepository
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+
+class PointServiceTest {
+
+    private val userPointRepository = mockk<UserPointRepository>()
+    private val pointService = PointService(userPointRepository)
+
+    @Test
+    fun getPointByUserId() {
+        val userId = 1L
+        val userPointExpected = UserPoint(userId, 2, 1)
+
+        every { userPointRepository.getPointByUserId(userId) } returns userPointExpected
+
+        val userPointResult = pointService.getPointByUserId(userId)
+
+        assert(userPointResult == userPointExpected)
+    }
+
+}

--- a/src/test/kotlin/io/hhplus/tdd/point/PointServiceTest.kt
+++ b/src/test/kotlin/io/hhplus/tdd/point/PointServiceTest.kt
@@ -85,4 +85,35 @@ class PointServiceTest {
         shouldThrow<IllegalArgumentException> { pointService.chargePoint(userId, chargeAmount) }
     }
 
+    @Test
+    fun usePoint() {
+        val userId = 1L
+        val initialPoint = 100L
+        val useAmount = 50L
+        val updatedPoint = initialPoint - useAmount
+
+        val userPoint = UserPoint(id = userId, point = initialPoint, updateMillis = System.currentTimeMillis())
+
+        every { userPointRepository.getPointByUserId(userId) } returns userPoint
+        every { userPointHistoryRepository.save(any()) }  answers { firstArg<PointHistory>() }
+        every { userPointRepository.save(any()) } answers { firstArg<UserPoint>() }
+
+        val result = pointService.usePoint(userId, useAmount)
+
+        result.id shouldBe userId
+        result.point shouldBe updatedPoint
+    }
+
+    @Test
+    fun usePoint_throws_IllegalArgumentException_cause_by_negative_point() {
+        val userId = 1L
+        val useAmount = -50L
+
+        val userPoint = UserPoint(id = userId, point = 100L, updateMillis = System.currentTimeMillis())
+
+        every { userPointRepository.getPointByUserId(userId) } returns userPoint
+
+        shouldThrow<IllegalArgumentException> { pointService.usePoint(userId, useAmount) }
+    }
+
 }

--- a/src/test/kotlin/io/hhplus/tdd/point/PointServiceTest.kt
+++ b/src/test/kotlin/io/hhplus/tdd/point/PointServiceTest.kt
@@ -2,6 +2,8 @@ package io.hhplus.tdd.point
 
 import io.hhplus.tdd.point.repository.PointHistoryRepository
 import io.hhplus.tdd.point.repository.UserPointRepository
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.jupiter.api.Test
@@ -52,5 +54,35 @@ class PointServiceTest {
         assert(actualPointHistories[1] == expectedPointHistories[1])
     }
 
+    @Test
+    fun chargePoint() {
+        val userId = 1L
+        val initialPoint = 100L
+        val chargeAmount = 50L
+        val updatedPoint = initialPoint + chargeAmount
+
+        val userPoint = UserPoint(id = userId, point = initialPoint, updateMillis = System.currentTimeMillis())
+
+        every { userPointRepository.getPointByUserId(userId) } returns userPoint
+        every { userPointHistoryRepository.save(any()) } answers { firstArg<PointHistory>() }
+        every { userPointRepository.save(any()) } answers { firstArg<UserPoint>() }
+
+        val result = pointService.chargePoint(userId, chargeAmount)
+
+        result.id shouldBe userId
+        result.point shouldBe updatedPoint
+    }
+
+    @Test
+    fun chargePoint_throws_IllegalArgumentException_cause_by_negative_point() {
+        val userId = 1L
+        val chargeAmount = -50L
+
+        val userPoint = UserPoint(id = userId, point = 100L, updateMillis = System.currentTimeMillis())
+
+        every { userPointRepository.getPointByUserId(userId) } returns userPoint
+
+        shouldThrow<IllegalArgumentException> { pointService.chargePoint(userId, chargeAmount) }
+    }
 
 }

--- a/src/test/kotlin/io/hhplus/tdd/point/PointServiceTest.kt
+++ b/src/test/kotlin/io/hhplus/tdd/point/PointServiceTest.kt
@@ -1,5 +1,6 @@
 package io.hhplus.tdd.point
 
+import io.hhplus.tdd.point.repository.PointHistoryRepository
 import io.hhplus.tdd.point.repository.UserPointRepository
 import io.mockk.every
 import io.mockk.mockk
@@ -8,7 +9,8 @@ import org.junit.jupiter.api.Test
 class PointServiceTest {
 
     private val userPointRepository = mockk<UserPointRepository>()
-    private val pointService = PointService(userPointRepository)
+    private val userPointHistoryRepository = mockk<PointHistoryRepository>()
+    private val pointService = PointService(userPointRepository, userPointHistoryRepository)
 
     @Test
     fun getPointByUserId() {
@@ -21,5 +23,34 @@ class PointServiceTest {
 
         assert(userPointResult == userPointExpected)
     }
+
+    @Test
+    fun getPointHistoriesByUserId_return_empty_history() {
+        val userId = 1L
+
+        every { userPointHistoryRepository.findByUserId(userId) } returns emptyList()
+
+        val pointHistories = pointService.getPointHistoriesByUserId(userId)
+
+        assert(pointHistories.isEmpty())
+    }
+
+    @Test
+    fun getPointHistoriesByUserId_return_multi_Histories() {
+        val userId = 1L
+
+        val expectedPointHistories = listOf(
+            PointHistory(1, userId, TransactionType.CHARGE, 1000, System.currentTimeMillis()),
+            PointHistory(2, userId, TransactionType.USE, 500, System.currentTimeMillis())
+        )
+        every { userPointHistoryRepository.findByUserId(userId) } returns expectedPointHistories
+        val actualPointHistories = pointService.getPointHistoriesByUserId(userId)
+
+        assert(actualPointHistories.isNotEmpty())
+        assert(actualPointHistories.size == 2)
+        assert(actualPointHistories[0] == expectedPointHistories[0])
+        assert(actualPointHistories[1] == expectedPointHistories[1])
+    }
+
 
 }

--- a/src/test/kotlin/io/hhplus/tdd/point/UserPointTest.kt
+++ b/src/test/kotlin/io/hhplus/tdd/point/UserPointTest.kt
@@ -1,0 +1,26 @@
+package io.hhplus.tdd.point
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+class UserPointTest {
+
+    @Test
+    fun addPoint() {
+        val userPoint = UserPoint(id = 1L, point = 100L, updateMillis = System.currentTimeMillis())
+        val result = userPoint.addPoint(50L)
+
+        userPoint.point shouldBe 100L
+        result.id shouldBe userPoint.id
+        result.point shouldBe 150L
+    }
+
+    @Test
+    fun addPoint_throws_IllegalArgumentException_cause_by_negative_point() {
+        val userPoint = UserPoint(id = 1L, point = 100L, updateMillis = System.currentTimeMillis())
+
+        shouldThrow<IllegalArgumentException> { userPoint.addPoint(-50L) }
+    }
+
+}

--- a/src/test/kotlin/io/hhplus/tdd/point/UserPointTest.kt
+++ b/src/test/kotlin/io/hhplus/tdd/point/UserPointTest.kt
@@ -23,4 +23,33 @@ class UserPointTest {
         shouldThrow<IllegalArgumentException> { userPoint.addPoint(-50L) }
     }
 
+    @Test
+    fun usePoint() {
+        val userPoint = UserPoint(id = 1L, point = 100L, updateMillis = System.currentTimeMillis())
+        val result = userPoint.usePoint(50L)
+
+        userPoint.point shouldBe 100L
+        result.id shouldBe userPoint.id
+        result.point shouldBe 50L
+    }
+
+    @Test
+    fun usePoint_throws_IllegalArgumentException_cause_by_negative_point() {
+        val userPoint = UserPoint(id = 1L, point = 100L, updateMillis = System.currentTimeMillis())
+
+        shouldThrow<IllegalArgumentException> { userPoint.usePoint(-50L) }.apply {
+            message shouldBe "사용할 포인트는 0 이상이어야 합니다."
+        }
+    }
+
+    @Test
+    fun usePoint_throws_IllegalArgumentException_cause_by_insufficient_point() {
+        val userPoint = UserPoint(id = 1L, point = 100L, updateMillis = System.currentTimeMillis())
+
+        shouldThrow<IllegalArgumentException> { userPoint.usePoint(150L) }.apply {
+            message shouldBe "포인트가 부족합니다."
+        }
+    }
+
+
 }

--- a/src/test/kotlin/io/hhplus/tdd/point/repository/PointHistoryRepositoryTest.kt
+++ b/src/test/kotlin/io/hhplus/tdd/point/repository/PointHistoryRepositoryTest.kt
@@ -1,0 +1,32 @@
+package io.hhplus.tdd.point.repository
+
+import io.hhplus.tdd.database.PointHistoryTable
+import io.hhplus.tdd.point.PointHistory
+import io.hhplus.tdd.point.TransactionType
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+
+import org.junit.jupiter.api.Assertions.*
+
+class PointHistoryRepositoryTest {
+
+    private val pointHistoryTable = mockk<PointHistoryTable>()
+    private val pointHistoryRepository = PointHistoryRepository(pointHistoryTable)
+
+    @Test
+    fun findByUserId() {
+        val userId = 1L
+        val expectedHistories = listOf(
+            PointHistory(1L, userId, TransactionType.CHARGE, 1000L, System.currentTimeMillis()),
+            PointHistory(2L, userId, TransactionType.USE, 500L, System.currentTimeMillis())
+        )
+
+        every { pointHistoryTable.selectAllByUserId(userId) } returns expectedHistories
+
+        val actualHistories = pointHistoryRepository.findByUserId(userId)
+
+        assertEquals(expectedHistories, actualHistories)
+    }
+
+}

--- a/src/test/kotlin/io/hhplus/tdd/point/repository/PointHistoryRepositoryTest.kt
+++ b/src/test/kotlin/io/hhplus/tdd/point/repository/PointHistoryRepositoryTest.kt
@@ -29,4 +29,22 @@ class PointHistoryRepositoryTest {
         assertEquals(expectedHistories, actualHistories)
     }
 
+    @Test
+    fun save() {
+        val pointHistory = PointHistory(1L, 1L, TransactionType.CHARGE, 1000L, System.currentTimeMillis())
+
+        every {
+            pointHistoryTable.insert(
+                pointHistory.userId,
+                pointHistory.amount,
+                pointHistory.type,
+                pointHistory.timeMillis
+            )
+        } returns pointHistory
+
+        val savedPointHistory = pointHistoryRepository.save(pointHistory)
+
+        assertEquals(pointHistory, savedPointHistory)
+    }
+
 }

--- a/src/test/kotlin/io/hhplus/tdd/point/repository/UserPointRepositoryTest.kt
+++ b/src/test/kotlin/io/hhplus/tdd/point/repository/UserPointRepositoryTest.kt
@@ -1,0 +1,27 @@
+package io.hhplus.tdd.point.repository
+
+import io.hhplus.tdd.database.UserPointTable
+import io.hhplus.tdd.point.UserPoint
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+class UserPointRepositoryTest {
+
+    private val userPointTable = mockk<UserPointTable>()
+    private val userPointRepository = UserPointRepository(userPointTable)
+
+    @Test
+    fun getPointByUserId() {
+        val userId = 1L
+        val expectedPoint = UserPoint(userId, 1000L, System.currentTimeMillis())
+
+        every { userPointTable.selectById(userId) } returns expectedPoint
+
+        val actualPoint = userPointRepository.getPointByUserId(userId)
+
+        assertEquals(expectedPoint, actualPoint)
+    }
+
+}

--- a/src/test/kotlin/io/hhplus/tdd/point/repository/UserPointRepositoryTest.kt
+++ b/src/test/kotlin/io/hhplus/tdd/point/repository/UserPointRepositoryTest.kt
@@ -24,4 +24,15 @@ class UserPointRepositoryTest {
         assertEquals(expectedPoint, actualPoint)
     }
 
+    @Test
+    fun save() {
+        val userPoint = UserPoint(id = 1L, point = 1000L, updateMillis = System.currentTimeMillis())
+
+        every { userPointTable.insertOrUpdate(userPoint.id, userPoint.point) } returns userPoint
+
+        val savedUserPoint = userPointRepository.save(userPoint)
+
+        assertEquals(userPoint, savedUserPoint)
+    }
+
 }


### PR DESCRIPTION
### **커밋 링크**
<!-- 
좋은 피드백을 받기 위해 가장 중요한 것은 코드를 작성할 때 커밋을 작업 단위로 잘 쪼개는 것입니다.
모든 작업을 하나의 커밋에 진행하고 PR을 하면 구조 파악에 많은 시간을 소모하기 때문에 절대로
좋은 피드백을 받을 수 없습니다.


필수 양식)
커밋 이름 : 커밋 링크

예시)
동시성 처리 : c83845
동시성 테스트 코드 : d93ji3
-->
- Feature: 사용자의 포인트 조회 API 구현 : 69535a8eeed40cc4c7b4be1f423c8b706f151c73
- Feature: 사용자의 포인트 충전/이용 내역 조회 API 구현 : 70d66ec04df9ef082d969c947dc9ec1afd6a0fbd
- Feature: 사용자의 포인트 충전 API 구현 : 5273e750dbce0c34e3b71434d637bd44a086922a
- Feature: 사용자의 포인트 충전/이용 내역 조회 Controller Unit Test 추가 : ba96dfb3f861f166b63e3abdfd56e7cc34e0bd34
- Feature: 사용자의 포인트 충전 Service Unit Test 추가 : 8a2d18811898649ff45148734a930ea6fe5c4c6b
- Feature: 사용자의 포인트 사용 API 구현 : c3adfe3dac65a7e65120541f32c0bbe22e730ff6
- Feature: 포인트 관련 통합 테스트 추가 : f3df3b381aa3c51b27bbc303d4947351cc1a2d2c

---
### **리뷰 포인트(질문)**
1. TDD, 테스트 코드 작성에 중점을 두었지만, 유저 관리에 대한 비즈니스적 정책이 미흡했던 것 같습니다. 이런 부분에 대해선 크게 염려하지 않아도 되겠죠?
2. JPA 를 사용하는 것 처럼 Repository 를 작성하였고 '불변 객체 패턴' 을 적용해보았습니다. 그런데 매번 데이터 객체 내부의 값이 변경이 필요할 때마다 새로운 객체를 반환하는 것은 성능이나 구현 측면에서 불이익이 발생할 것 같은데 다르게 적용하는 방법이 있을까요?
3. 통합 테스트(f3df3b381aa3c51b27bbc303d4947351cc1a2d2c)의 경우 `@beforeEach` 로 데이터를 clear & preset 하려 했는데 database 패키지의 구현체는 수정하지 않는 제한이 있어 테스트 코드가 깔끔하진 않은 것 같습니다. 혹시 제한이 없었다면 이런 현상은 없었을까요? 아니면 제가 생각하지 못한 다른 방법이 있을까요?
<!-- - 리뷰어가 특히 확인해야 할 부분이나 신경 써야 할 코드가 있다면 명확히 작성해주세요.(최대 2개)
  
  좋은 예:
  - `ErrorMessage` 컴포넌트의 상태 업데이트 로직이 적절한지 검토 부탁드립니다.
  - 추가한 유닛 테스트(`LoginError.test.js`)의 테스트 케이스가 충분한지 확인 부탁드립니다.

  나쁜 예:
  - 개선사항을 알려주세요.
  - 코드 전반적으로 봐주세요.
  - 뭘 질문할지 모르겠어요. -->
---
### **이번주 KPT 회고**

### Keep
<!-- 유지해야 할 좋은 점 -->
- 코틀린스러운 스타일과 kotest 를 사용한 테스트를 적용해 본 것 (Kotlin 으로 처음 프로젝트를 해봅니다.)

### Problem
<!--개선이 필요한 점-->
- 좀 더 정교한 요구사항 분석과 적용이 필요

### Try
<!-- 새롭게 시도할 점 -->
- Kotlin 의 [여러 테스팅 스타일](https://kotest.io/docs/framework/testing-styles.html)을 적용해 보기